### PR TITLE
increase ulimit to minimum recommendation

### DIFF
--- a/jobs/caddy/templates/bin/control.erb
+++ b/jobs/caddy/templates/bin/control.erb
@@ -22,6 +22,8 @@ chown vcap:vcap "$RUNDIR"
 case $1 in
 
   start)
+    ulimit -n 8192
+
     /sbin/start-stop-daemon \
       --background \
       --pidfile "$PIDFILE" \


### PR DESCRIPTION
When caddy starts up, the /var/vcap/sys/log/caddy/stdout.log file shows the following warning:

WARNING: File descriptor limit 1024 is too low for production servers. At least 8192 is recommended. Fix with `ulimit -n 8192`.